### PR TITLE
Solve ambiguous occurrence of defaultTimeLocale

### DIFF
--- a/src/Macbeth/Fics/FicsConnection.hs
+++ b/src/Macbeth/Fics/FicsConnection.hs
@@ -152,8 +152,8 @@ printCmdMsg cmd = print cmd
 
 logFile :: FilePath -> BS.ByteString -> IO ()
 logFile path chunk = do
-  date <- fmap (formatTime defaultTimeLocale "%Y-%m-%d_") getZonedTime
-  dateTime <- fmap (formatTime defaultTimeLocale "%Y-%m-%d %H-%M-%S: ") getZonedTime
+  date <- fmap (formatTime Data.Time.defaultTimeLocale "%Y-%m-%d_") getZonedTime
+  dateTime <- fmap (formatTime Data.Time.defaultTimeLocale "%Y-%m-%d %H-%M-%S: ") getZonedTime
   appendFile (path </> date ++ "macbeth.log") $
     (foldr (.) (showString $ "\n" ++ dateTime) $ fmap showLitChar (BS.unpack chunk)) ""
 

--- a/src/Macbeth/Utils/PGN.hs
+++ b/src/Macbeth/Utils/PGN.hs
@@ -30,7 +30,7 @@ saveAsPGN' moves mGameResult = do
 
 filepath :: FilePath -> ZonedTime -> Move -> IO FilePath
 filepath appDir dateTime m = return $ appDir </>
-  formatTime defaultTimeLocale "%Y-%m-%d_%H-%M-%S_" dateTime ++ nameW m ++ "_vs_" ++ nameB m ++ ".pgn"
+  formatTime Data.Time.defaultTimeLocale "%Y-%m-%d_%H-%M-%S_" dateTime ++ nameW m ++ "_vs_" ++ nameB m ++ ".pgn"
 
 toPGN :: [Move] -> Maybe GameResult -> ZonedTime -> String
 toPGN [] _ _ = ""
@@ -46,8 +46,8 @@ tagsSection :: Move -> Maybe GameResult -> ZonedTime -> String
 tagsSection m mGameResult dateTime =
   "[Event \"?\"]\n\
   \[Site \"?\"]\n\
-  \[Date \"" ++ formatTime defaultTimeLocale "%Y.%m.%d" dateTime ++ "\"]\n\
-  \[Time \"" ++ formatTime defaultTimeLocale "%T" dateTime ++ "\"]\n\
+  \[Date \"" ++ formatTime Data.Time.defaultTimeLocale "%Y.%m.%d" dateTime ++ "\"]\n\
+  \[Time \"" ++ formatTime Data.Time.defaultTimeLocale "%T" dateTime ++ "\"]\n\
   \[Round \"?\"]\n\
   \[White \"" ++ nameW m ++ "\"]\n\
   \[Black \"" ++ nameB m ++ "\"]\n\


### PR DESCRIPTION
GHC generated several messages like:

```
src\Macbeth\Utils\PGN.hs:33:14:
    Ambiguous occurrence `defaultTimeLocale'
    It could refer to either `Data.Time.defaultTimeLocale',
                             imported from `Data.Time' at src\Macbeth\Utils\PGN.hs:14:1-16
                             (and originally defined in `time-1.5.0.1:Data.Time.Format.Locale')
                          or `System.Locale.defaultTimeLocale',
                             imported from `System.Locale' at src\Macbeth\Utils\PGN.hs:16:1-20

```
