### PR TITLE
Added the name of the license file to the .cabal file

### DIFF
--- a/Macbeth.cabal
+++ b/Macbeth.cabal
@@ -3,7 +3,7 @@ version: 0.0.9
 cabal-version: >= 1.8
 build-type: Simple
 license: AllRightsReserved
-license-file: ""
+license-file: "LICENSE"
 data-dir: resources
 
 library


### PR DESCRIPTION
Without the file name, cabal-install gives the message:
  setup-Simple-Cabal-1.22.5.0-x86_64-windows-ghc-7.10.3.exe: : does not exist
and refuses to compile
